### PR TITLE
Fix grammar in UserSocket.id/1 documentation

### DIFF
--- a/installer/templates/phx_web/channels/user_socket.ex
+++ b/installer/templates/phx_web/channels/user_socket.ex
@@ -23,7 +23,7 @@ defmodule <%= web_namespace %>.UserSocket do
     {:ok, socket}
   end
 
-  # Socket id's are topics that allow you to identify all sockets for a given user:
+  # Socket ids are topics that allow you to identify all sockets for a given user:
   #
   #     def id(socket), do: "user_socket:#{socket.assigns.user_id}"
   #


### PR DESCRIPTION
Found a stray apostrophe in the `UserSocket.id/1` documentation (see Rule 2b on [this page](http://www.grammarbook.com/punctuation/apostro.asp)). This pull request removes it!

Also, sorry if this is way too trivial for a pull request; I'm currently going through the "Programming Phoenix" book for the first time and I'm loving it, so I got really excited at the idea of contributing anything at all 😇 